### PR TITLE
Add env var `CACHE_DIR` for pyQuARC to use

### DIFF
--- a/deploy/deploy/stack.py
+++ b/deploy/deploy/stack.py
@@ -37,6 +37,7 @@ class AppStack(core.Stack):
             handler="handler",
             layers=[pyQuARC_layer],
             function_name=f"{construct_id}-runner",
+            environment={"CACHE_DIR": "/tmp"},
         )
 
         # The API Gateway that the integrates with the lambda function, where clients can submit requests


### PR DESCRIPTION
# Description
pyQuARC was failing on url checks in Windows because the `cache_dir` param `/tmp` isn't writable in Windows. 
pyQuARC makes it configurable in <placeholder release>, defaults to `None`. So, this PR makes sure we pass the correct value for it to work in lambda properly.
