### PR TITLE
Update GitHub Actions to Node 24 majors and Python 3.9

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v5
 
       - name: Set environment based on branch
         run: |
@@ -24,14 +24,14 @@ jobs:
           fi
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ secrets.AWS_REGION }}
 
       - name: Setup python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v6
         with:
           python-version: 3.9
 
@@ -41,9 +41,9 @@ jobs:
           python helpers/update_pyquarc.py --force
 
       - name: Use Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v5
         with:
-          node-version: "14.15.1"
+          node-version: "20"
 
       - name: Install CDK
         run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,18 +10,18 @@ jobs:
 
     steps:
       - name: Check out Git repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v5
 
       - name: Set up Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v6
         with:
-          python-version: 3.8
+          python-version: 3.9
 
       - name: Install Python dependencies
         run: pip install black flake8
 
       - name: Run linters
-        uses: wearerequired/lint-action@v1
+        uses: wearerequired/lint-action@v2
         with:
           black: true
           flake8: true

--- a/.github/workflows/update_pyquarc.yml
+++ b/.github/workflows/update_pyquarc.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v5
 
       - name: Set environment based on branch
         run: |
@@ -21,14 +21,14 @@ jobs:
           fi
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ secrets.AWS_REGION }}
 
       - name: Setup python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v6
         with:
           python-version: 3.9
 

--- a/deploy/app.py
+++ b/deploy/app.py
@@ -6,7 +6,6 @@ from aws_cdk import App
 
 from deploy.stack import AppStack
 
-
 app = App()
 AppStack(app, f"{APP_NAME}-{ENV}")
 

--- a/deploy/deploy/stack.py
+++ b/deploy/deploy/stack.py
@@ -5,7 +5,6 @@ from aws_cdk import (
     aws_lambda as lambda_,
     aws_apigateway as apigateway,
     BundlingOptions,
-    DockerImage,
 )
 
 
@@ -37,8 +36,10 @@ class AppStack(Stack):
                 bundling=BundlingOptions(
                     image=lambda_.Runtime.PYTHON_3_9.bundling_image,
                     command=[
-                        "sh", "-c", "pip install -r requirements.txt -t /asset-output && cp -au . /asset-output"
-                    ]
+                        "sh",
+                        "-c",
+                        "pip install -r requirements.txt -t /asset-output && cp -au . /asset-output",
+                    ],
                 ),
             ),
             runtime=lambda_.Runtime.PYTHON_3_9,


### PR DESCRIPTION
## Problem

The lint workflow is failing:

```
Error: Version 3.8 with arch x64 not found
```

`ubuntu-latest` runners no longer ship Python 3.8, and the older action majors (`@v1`/`@v2`) run on the now-deprecated Node 20.

## Changes

- **lint.yml** — `setup-python@v1` (3.8) → `@v6` (3.9, matching the Lambda runtime and the deploy workflows); `checkout@v2` → `@v5`; `wearerequired/lint-action@v1` → `@v2`.
- **deploy.yml / update_pyquarc.yml** — `checkout@v2` → `@v5`, `configure-aws-credentials@v1` → `@v4`, `setup-python@v2` → `@v6`.
- **deploy.yml** — `setup-node@v2` → `@v5`, and bump the CDK build Node from the EOL `14.15.1` to `20` LTS.

All three workflow files parse as valid YAML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)