### PR TITLE
Build pyQuARC layer in Lambda-compatible Docker image

### DIFF
--- a/helpers/update_pyquarc.py
+++ b/helpers/update_pyquarc.py
@@ -37,7 +37,15 @@ def install(zip_file):
     zip_file.extractall("tmp/")
     # Get the first directory in the list (folder name is pyQuARC<SOMEHASH>)
     directory = [x for x in os.listdir("tmp/") if os.path.isdir(f"tmp/{x}")][0]
-    return os.system(f"pip install tmp/{directory} --target=layers/pyQuARC/python")
+    # Build inside the Lambda-compatible image (Amazon Linux 2, glibc 2.26) so
+    # pip selects manylinux wheels the python3.9 runtime can actually load;
+    # a plain pip install on the CI runner picks manylinux_2_28 wheels
+    # (e.g. lxml >= 5) that fail at import time with GLIBC_2.28 errors.
+    return os.system(
+        'docker run --rm --platform linux/amd64 -v "$PWD":/work -w /work '
+        "public.ecr.aws/sam/build-python3.9 "
+        f"pip install tmp/{directory} --target=layers/pyQuARC/python"
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Plain pip install on the ubuntu-latest runner selects manylinux_2_28 wheels (lxml >= 5) that require glibc 2.28, but the python3.9 Lambda runtime runs on Amazon Linux 2 with glibc 2.26, causing:

  Runtime.ImportModuleError: /lib64/libc.so.6: version 'GLIBC_2.28'
  not found (required by /opt/python/lxml/etree...so)

Run the layer pip install inside public.ecr.aws/sam/build-python3.9 (AL2, glibc 2.26) so pip resolves manylinux_2_17 wheels and any sdist builds link against the runtime's glibc. Verified: layer built this way imports lxml 5.3.0 on AL2; max required symbol is GLIBC_2.14.